### PR TITLE
docs: remind to sync LoRa-SDR submodule

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,12 @@ The `vectors/golden/` directory contains essential test vectors:
 
 These vectors are generated from the original LoRa-SDR submodule and provide bit-exact validation.
 
+**Note:** Before running any vector generation scripts, synchronize the `external/LoRa-SDR` submodule:
+
+```bash
+git submodule update --init --recursive
+```
+
 ## Testing
 
 The library includes comprehensive tests:


### PR DESCRIPTION
## Summary
- initialize `external/LoRa-SDR` submodule at commit `c545c51e5e37284363a971ec298f72255646a6fa`
- document syncing the submodule before running vector scripts

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: alloc_tracker.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68c01ea696f883298c582d35d79b691f