### PR TITLE
docs: fix broken test plan link

### DIFF
--- a/TEST_PLAN.md
+++ b/TEST_PLAN.md
@@ -5,8 +5,8 @@
 See also: [API Specification](API_SPEC.md), [Porting Notes](PORTING_NOTES.md), [Third-Party Components](THIRD_PARTY.md)
 
 ## Overview
-This document outlines how the library is validated. Detailed build and execution
-steps are provided in [README_TESTING.md](README_TESTING.md).
+This document outlines how the library is validated. Build and execution steps are
+documented in the project [README](README.md).
 
 ## Bit-Exact Regression Tests
 Verifies modulation and demodulation against deterministic reference vectors.


### PR DESCRIPTION
## Summary
- fix test plan to reference existing README for build instructions

## Testing
- `cmake -B build -S .`
- `cmake --build build` *(fails: alloc_tracker.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c02315bac88329b0dddf343fdac2c0