### PR TITLE
chore: enforce C++17 standard

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(lora_phy LANGUAGES CXX)
 
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 add_compile_options(-Wall -Wextra -Wpedantic -O2)

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The library includes comprehensive tests:
 ## Dependencies
 
 - **KISS-FFT**: Header-only FFT library (included)
-- **C++17**: Modern C++ features
+- **C++17**: Requires a C++17-compatible compiler
 - **CMake**: Build system
 
 ## License


### PR DESCRIPTION
## Summary
- require C++17 when building the library
- clarify C++17 compiler requirement in documentation

## Testing
- `cmake .. && make` *(fails: fatal error: alloc_tracker.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68c023d285548329ab443d37d4b1475e