### PR TITLE
Handle missing scratch buffer in demodulator

### DIFF
--- a/include/lora_phy/phy.hpp
+++ b/include/lora_phy/phy.hpp
@@ -203,10 +203,13 @@ size_t lora_modulate(const uint16_t* symbols, size_t symbol_count,
                      uint8_t sync = 0x12);
 
 // Demodulate complex samples into symbol indices using a prepared workspace.
-size_t lora_demodulate(lora_demod_workspace* ws,
-                       const std::complex<float>* samples, size_t sample_count,
-                       uint16_t* out_symbols, unsigned osr,
-                       uint8_t* out_sync = nullptr);
+// Returns the number of symbols produced or -ERANGE when the scratch buffer
+// inside ``ws`` is missing or too small to normalise inputs that exceed the
+// canonical [-1.0, 1.0] range.
+ssize_t lora_demodulate(lora_demod_workspace* ws,
+                        const std::complex<float>* samples, size_t sample_count,
+                        uint16_t* out_symbols, unsigned osr,
+                        uint8_t* out_sync = nullptr);
 
 // Simple Hamming(8,4) based encoder. Each input byte becomes two symbols.
 size_t lora_encode(const uint8_t* bytes, size_t byte_count,

--- a/src/phy/LoRaDemod.cpp
+++ b/src/phy/LoRaDemod.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cmath>
 #include <new>
+#include <cerrno>
 
 namespace lora_phy {
 
@@ -46,7 +47,7 @@ void lora_demod_free(lora_demod_workspace* ws)
     ws->scratch_len = 0;
 }
 
-size_t lora_demodulate(lora_demod_workspace* ws,
+ssize_t lora_demodulate(lora_demod_workspace* ws,
                        const std::complex<float>* samples, size_t sample_count,
                        uint16_t* out_symbols, unsigned osr,
                        uint8_t* out_sync)
@@ -67,7 +68,7 @@ size_t lora_demodulate(lora_demod_workspace* ws,
     }
     if (max_amp > 1.0f) {
         if (!ws->scratch || ws->scratch_len < sample_count) {
-            return 0;
+            return -ERANGE;
         }
         float scale = 1.0f / max_amp;
         for (size_t i = 0; i < sample_count; ++i) {
@@ -191,7 +192,8 @@ size_t lora_demodulate(lora_demod_workspace* ws,
         }
     }
 
-    return have_sync ? out_idx : total_symbols;
+    return have_sync ? static_cast<ssize_t>(out_idx)
+                     : static_cast<ssize_t>(total_symbols);
 }
 
 } // namespace lora_phy

--- a/tests/scratch_buffer_error_test.cpp
+++ b/tests/scratch_buffer_error_test.cpp
@@ -1,0 +1,26 @@
+#include <lora_phy/phy.hpp>
+#include <cerrno>
+#include <complex>
+#include <iostream>
+#include <vector>
+
+int main() {
+    using namespace lora_phy;
+    const unsigned sf = 7;
+    const size_t N = size_t(1) << sf;
+
+    lora_demod_workspace ws{};
+    lora_demod_init(&ws, sf, window_type::window_none, nullptr, 0);
+
+    std::vector<std::complex<float>> samples(N, std::complex<float>(2.0f, 0.0f));
+    std::vector<uint16_t> out(1);
+    ssize_t rc = lora_demodulate(&ws, samples.data(), samples.size(), out.data(), 1);
+
+    lora_demod_free(&ws);
+
+    if (rc != -ERANGE) {
+        std::cerr << "Expected -ERANGE, got " << rc << std::endl;
+        return 1;
+    }
+    return 0;
+}

--- a/tests/sync_word_test.cpp
+++ b/tests/sync_word_test.cpp
@@ -55,9 +55,9 @@ int main() {
                               scratch.data(), scratch.size());
     uint8_t out_sync = 0;
     std::vector<uint16_t> dummy(1);
-    size_t produced = lora_phy::lora_demodulate(&ws, samples.data(),
-                                                sample_count, dummy.data(), 1,
-                                                &out_sync);
+    ssize_t produced = lora_phy::lora_demodulate(&ws, samples.data(),
+                                                 sample_count, dummy.data(), 1,
+                                                 &out_sync);
     lora_phy::lora_demod_free(&ws);
 
     bool ok = same && produced == 0 && out_sync == sync;

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -9,6 +9,7 @@ int whitening_test_main();
 int equal_power_bin_test_main();
 int sync_word_test_main();
 int error_code_test_main();
+int scratch_buffer_error_test_main();
 
 int main() {
     int result = 0;
@@ -21,6 +22,7 @@ int main() {
     result |= equal_power_bin_test_main();
     result |= sync_word_test_main();
     result |= error_code_test_main();
+    result |= scratch_buffer_error_test_main();
     if (result != 0) {
         std::printf("Some tests failed\n");
     }


### PR DESCRIPTION
## Summary
- return `-ERANGE` from `lora_demodulate` when normalization is required but scratch space is absent or too small
- document scratch buffer requirement and error code
- add unit test for oversised samples without scratch buffer

## Testing
- `cmake --build build`
- `ctest --test-dir build` *(fails: Subprocess aborted)*
- `g++ -std=c++17 -Iinclude tests/scratch_buffer_error_test.cpp build/liblora_phy.a -o scratch_test && ./scratch_test && echo scratch_test_passed`


------
https://chatgpt.com/codex/tasks/task_e_68c028b350c88329993b4047f163811d