### PR TITLE
Implement AES-CMAC MIC for LoRaWAN

### DIFF
--- a/API_SPEC.md
+++ b/API_SPEC.md
@@ -110,24 +110,28 @@ parse frames.
 * `lorawan::Frame` – aggregates `MHDR`, `FHDR` and the FRMPayload bytes.
 
 ### `ssize_t lorawan::build_frame(lora_phy::lora_workspace *ws,
+                                  const uint8_t nwk_skey[16],
                                   const lorawan::Frame &frame,
                                   uint16_t *symbols,
                                   size_t symbol_cap,
                                   uint8_t *tmp_bytes,
                                   size_t tmp_cap);`
-Serialises `frame`, appends a CRC32-based MIC and encodes the resulting buffer
-into LoRa symbols using `lora_phy::encode`.  `tmp_bytes` must point to a caller
-provided workspace for the intermediate byte representation.  Returns the
-number of symbols written or a negative value on error.
+Serialises `frame`, computes the LoRaWAN MIC using AES‑128 CMAC with
+`nwk_skey`, appends it and encodes the resulting buffer into LoRa symbols using
+`lora_phy::encode`.  `tmp_bytes` must point to a caller provided workspace for
+the intermediate byte representation.  Returns the number of symbols written or
+a negative value on error.
 
 ### `ssize_t lorawan::parse_frame(lora_phy::lora_workspace *ws,
+                                  const uint8_t nwk_skey[16],
                                   const uint16_t *symbols, size_t count,
                                   lorawan::Frame &out,
                                   uint8_t *tmp_bytes,
                                   size_t tmp_cap);`
-Decodes symbols with `lora_phy::decode`, verifies the MIC and populates `out`
-with the parsed fields using `tmp_bytes` as scratch space.  The return value is
-the number of payload bytes or a negative error code.
+Decodes symbols with `lora_phy::decode`, verifies the AES‑128 CMAC‑based MIC
+using `nwk_skey` and populates `out` with the parsed fields using `tmp_bytes`
+as scratch space.  The return value is the number of payload bytes or a negative
+error code.
 
 ## Buffer Ownership and Error Handling
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.5)
-project(lora_phy LANGUAGES CXX)
+project(lora_phy LANGUAGES C CXX)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -40,7 +40,7 @@ if(BUILD_TESTS)
     file(GLOB TEST_SOURCES CONFIGURE_DEPENDS tests/*.cpp)
     list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_main.cpp)
 
-    add_executable(lora_phy_tests tests/test_main.cpp ${TEST_SOURCES} src/lorawan/lorawan.cpp)
+    add_executable(lora_phy_tests tests/test_main.cpp ${TEST_SOURCES} src/lorawan/lorawan.cpp src/lorawan/aes.c)
     target_link_libraries(lora_phy_tests PRIVATE lora_phy)
 
     foreach(test_src ${TEST_SOURCES})

--- a/THIRD_PARTY.md
+++ b/THIRD_PARTY.md
@@ -19,3 +19,9 @@ This project incorporates external code and artifacts. The sections below credit
 - **Local modifications:** Code was refactored to remove the Pothos framework, rely solely on KISS FFT, and avoid runtime allocations.
 - **Vector regeneration:** Baseline vectors can be reproduced using `scripts/generate_baseline_vectors.py`, which invokes `scripts/generate_vectors.sh` and the original LoRa-SDR binary. The generated vectors are stored under `legacy_vectors/lorasdr_baseline`.
 
+## tiny-AES-c
+- **Source:** [https://github.com/kokke/tiny-AES-c](https://github.com/kokke/tiny-AES-c)
+- **License:** Unlicense / Public Domain
+- **Usage:** Provides the AES-128 block cipher used for CMAC-based MIC calculation.
+- **Local modifications:** CBC and CTR modes were disabled and the header was wrapped for C++ consumption.
+

--- a/include/lorawan/aes.h
+++ b/include/lorawan/aes.h
@@ -1,0 +1,99 @@
+#ifndef _AES_H_
+#define _AES_H_
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// #define the macros below to 1/0 to enable/disable the mode of operation.
+//
+// CBC enables AES encryption in CBC-mode of operation.
+// CTR enables encryption in counter-mode.
+// ECB enables the basic ECB 16-byte block algorithm. All can be enabled simultaneously.
+
+// The #ifndef-guard allows it to be configured before #include'ing or at compile time.
+#ifndef CBC
+  #define CBC 0
+#endif
+
+#ifndef ECB
+  #define ECB 1
+#endif
+
+#ifndef CTR
+  #define CTR 0
+#endif
+
+
+#define AES128 1
+//#define AES192 1
+//#define AES256 1
+
+#define AES_BLOCKLEN 16 // Block length in bytes - AES is 128b block only
+
+#if defined(AES256) && (AES256 == 1)
+    #define AES_KEYLEN 32
+    #define AES_keyExpSize 240
+#elif defined(AES192) && (AES192 == 1)
+    #define AES_KEYLEN 24
+    #define AES_keyExpSize 208
+#else
+    #define AES_KEYLEN 16   // Key length in bytes
+    #define AES_keyExpSize 176
+#endif
+
+struct AES_ctx
+{
+  uint8_t RoundKey[AES_keyExpSize];
+#if (defined(CBC) && (CBC == 1)) || (defined(CTR) && (CTR == 1))
+  uint8_t Iv[AES_BLOCKLEN];
+#endif
+};
+
+void AES_init_ctx(struct AES_ctx* ctx, const uint8_t* key);
+#if (defined(CBC) && (CBC == 1)) || (defined(CTR) && (CTR == 1))
+void AES_init_ctx_iv(struct AES_ctx* ctx, const uint8_t* key, const uint8_t* iv);
+void AES_ctx_set_iv(struct AES_ctx* ctx, const uint8_t* iv);
+#endif
+
+#if defined(ECB) && (ECB == 1)
+// buffer size is exactly AES_BLOCKLEN bytes; 
+// you need only AES_init_ctx as IV is not used in ECB 
+// NB: ECB is considered insecure for most uses
+void AES_ECB_encrypt(const struct AES_ctx* ctx, uint8_t* buf);
+void AES_ECB_decrypt(const struct AES_ctx* ctx, uint8_t* buf);
+
+#endif // #if defined(ECB) && (ECB == !)
+
+
+#if defined(CBC) && (CBC == 1)
+// buffer size MUST be mutile of AES_BLOCKLEN;
+// Suggest https://en.wikipedia.org/wiki/Padding_(cryptography)#PKCS7 for padding scheme
+// NOTES: you need to set IV in ctx via AES_init_ctx_iv() or AES_ctx_set_iv()
+//        no IV should ever be reused with the same key 
+void AES_CBC_encrypt_buffer(struct AES_ctx* ctx, uint8_t* buf, size_t length);
+void AES_CBC_decrypt_buffer(struct AES_ctx* ctx, uint8_t* buf, size_t length);
+
+#endif // #if defined(CBC) && (CBC == 1)
+
+
+#if defined(CTR) && (CTR == 1)
+
+// Same function for encrypting as for decrypting. 
+// IV is incremented for every block, and used after encryption as XOR-compliment for output
+// Suggesting https://en.wikipedia.org/wiki/Padding_(cryptography)#PKCS7 for padding scheme
+// NOTES: you need to set IV in ctx with AES_init_ctx_iv() or AES_ctx_set_iv()
+//        no IV should ever be reused with the same key 
+void AES_CTR_xcrypt_buffer(struct AES_ctx* ctx, uint8_t* buf, size_t length);
+
+#endif // #if defined(CTR) && (CTR == 1)
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // _AES_H_

--- a/include/lorawan/lorawan.hpp
+++ b/include/lorawan/lorawan.hpp
@@ -42,11 +42,23 @@ struct Frame {
     std::vector<uint8_t> payload; // FRMPayload bytes
 };
 
-// Compute MIC over @p data using CRC32
-uint32_t compute_mic(const uint8_t* data, size_t len);
+// Compute the LoRaWAN MIC using AES-128 CMAC.
+// @param nwk_skey 16-byte network session key used for MIC calculation.
+// @param uplink  true for uplink frames, false for downlink.
+// @param devaddr Device address.
+// @param fcnt    32-bit frame counter.
+// @param data    Pointer to MHDR||FHDR||(FPort||FRMPayload) bytes.
+// @param len     Length of @p data in bytes.
+uint32_t compute_mic(const uint8_t nwk_skey[16],
+                     bool uplink,
+                     uint32_t devaddr,
+                     uint32_t fcnt,
+                     const uint8_t* data,
+                     size_t len);
 
 // Build @p frame into LoRa symbols using lora_phy::encode()
 ssize_t build_frame(lora_phy::lora_workspace* ws,
+                    const uint8_t nwk_skey[16],
                     const Frame& frame,
                     uint16_t* symbols,
                     size_t symbol_cap,
@@ -55,6 +67,7 @@ ssize_t build_frame(lora_phy::lora_workspace* ws,
 
 // Parse symbols back into a Frame verifying the MIC
 ssize_t parse_frame(lora_phy::lora_workspace* ws,
+                    const uint8_t nwk_skey[16],
                     const uint16_t* symbols,
                     size_t symbol_count,
                     Frame& out,

--- a/runners/lorawan_roundtrip.cpp
+++ b/runners/lorawan_roundtrip.cpp
@@ -49,7 +49,8 @@ int main(int argc, char** argv) {
 
     std::vector<uint16_t> symbols(payload.size() * 2 + 32);
     std::vector<uint8_t> tmp(symbols.size() / 2 + 8);
-    ssize_t sc = lorawan::build_frame(&ws, frame, symbols.data(), symbols.size(),
+    uint8_t nwk_skey[16] = {};
+    ssize_t sc = lorawan::build_frame(&ws, nwk_skey, frame, symbols.data(), symbols.size(),
                                       tmp.data(), tmp.size());
     if (sc < 0) {
         std::cerr << "build_frame failed\n";
@@ -57,7 +58,7 @@ int main(int argc, char** argv) {
     }
 
     lorawan::Frame parsed;
-    ssize_t pc = lorawan::parse_frame(&ws, symbols.data(), static_cast<size_t>(sc),
+    ssize_t pc = lorawan::parse_frame(&ws, nwk_skey, symbols.data(), static_cast<size_t>(sc),
                                       parsed, tmp.data(), tmp.size());
     if (pc < 0) {
         std::cerr << "parse_frame failed\n";

--- a/src/lorawan/aes.c
+++ b/src/lorawan/aes.c
@@ -1,0 +1,572 @@
+/*
+
+This is an implementation of the AES algorithm, specifically ECB, CTR and CBC mode.
+Block size can be chosen in aes.h - available choices are AES128, AES192, AES256.
+
+The implementation is verified against the test vectors in:
+  National Institute of Standards and Technology Special Publication 800-38A 2001 ED
+
+ECB-AES128
+----------
+
+  plain-text:
+    6bc1bee22e409f96e93d7e117393172a
+    ae2d8a571e03ac9c9eb76fac45af8e51
+    30c81c46a35ce411e5fbc1191a0a52ef
+    f69f2445df4f9b17ad2b417be66c3710
+
+  key:
+    2b7e151628aed2a6abf7158809cf4f3c
+
+  resulting cipher
+    3ad77bb40d7a3660a89ecaf32466ef97 
+    f5d3d58503b9699de785895a96fdbaaf 
+    43b1cd7f598ece23881b00e3ed030688 
+    7b0c785e27e8ad3f8223207104725dd4 
+
+
+NOTE:   String length must be evenly divisible by 16byte (str_len % 16 == 0)
+        You should pad the end of the string with zeros if this is not the case.
+        For AES192/256 the key size is proportionally larger.
+
+*/
+
+
+/*****************************************************************************/
+/* Includes:                                                                 */
+/*****************************************************************************/
+#include <string.h> // CBC mode, for memset
+#include <lorawan/aes.h>
+
+/*****************************************************************************/
+/* Defines:                                                                  */
+/*****************************************************************************/
+// The number of columns comprising a state in AES. This is a constant in AES. Value=4
+#define Nb 4
+
+#if defined(AES256) && (AES256 == 1)
+    #define Nk 8
+    #define Nr 14
+#elif defined(AES192) && (AES192 == 1)
+    #define Nk 6
+    #define Nr 12
+#else
+    #define Nk 4        // The number of 32 bit words in a key.
+    #define Nr 10       // The number of rounds in AES Cipher.
+#endif
+
+// jcallan@github points out that declaring Multiply as a function 
+// reduces code size considerably with the Keil ARM compiler.
+// See this link for more information: https://github.com/kokke/tiny-AES-C/pull/3
+#ifndef MULTIPLY_AS_A_FUNCTION
+  #define MULTIPLY_AS_A_FUNCTION 0
+#endif
+
+
+
+
+/*****************************************************************************/
+/* Private variables:                                                        */
+/*****************************************************************************/
+// state - array holding the intermediate results during decryption.
+typedef uint8_t state_t[4][4];
+
+
+
+// The lookup-tables are marked const so they can be placed in read-only storage instead of RAM
+// The numbers below can be computed dynamically trading ROM for RAM - 
+// This can be useful in (embedded) bootloader applications, where ROM is often limited.
+static const uint8_t sbox[256] = {
+  //0     1    2      3     4    5     6     7      8    9     A      B    C     D     E     F
+  0x63, 0x7c, 0x77, 0x7b, 0xf2, 0x6b, 0x6f, 0xc5, 0x30, 0x01, 0x67, 0x2b, 0xfe, 0xd7, 0xab, 0x76,
+  0xca, 0x82, 0xc9, 0x7d, 0xfa, 0x59, 0x47, 0xf0, 0xad, 0xd4, 0xa2, 0xaf, 0x9c, 0xa4, 0x72, 0xc0,
+  0xb7, 0xfd, 0x93, 0x26, 0x36, 0x3f, 0xf7, 0xcc, 0x34, 0xa5, 0xe5, 0xf1, 0x71, 0xd8, 0x31, 0x15,
+  0x04, 0xc7, 0x23, 0xc3, 0x18, 0x96, 0x05, 0x9a, 0x07, 0x12, 0x80, 0xe2, 0xeb, 0x27, 0xb2, 0x75,
+  0x09, 0x83, 0x2c, 0x1a, 0x1b, 0x6e, 0x5a, 0xa0, 0x52, 0x3b, 0xd6, 0xb3, 0x29, 0xe3, 0x2f, 0x84,
+  0x53, 0xd1, 0x00, 0xed, 0x20, 0xfc, 0xb1, 0x5b, 0x6a, 0xcb, 0xbe, 0x39, 0x4a, 0x4c, 0x58, 0xcf,
+  0xd0, 0xef, 0xaa, 0xfb, 0x43, 0x4d, 0x33, 0x85, 0x45, 0xf9, 0x02, 0x7f, 0x50, 0x3c, 0x9f, 0xa8,
+  0x51, 0xa3, 0x40, 0x8f, 0x92, 0x9d, 0x38, 0xf5, 0xbc, 0xb6, 0xda, 0x21, 0x10, 0xff, 0xf3, 0xd2,
+  0xcd, 0x0c, 0x13, 0xec, 0x5f, 0x97, 0x44, 0x17, 0xc4, 0xa7, 0x7e, 0x3d, 0x64, 0x5d, 0x19, 0x73,
+  0x60, 0x81, 0x4f, 0xdc, 0x22, 0x2a, 0x90, 0x88, 0x46, 0xee, 0xb8, 0x14, 0xde, 0x5e, 0x0b, 0xdb,
+  0xe0, 0x32, 0x3a, 0x0a, 0x49, 0x06, 0x24, 0x5c, 0xc2, 0xd3, 0xac, 0x62, 0x91, 0x95, 0xe4, 0x79,
+  0xe7, 0xc8, 0x37, 0x6d, 0x8d, 0xd5, 0x4e, 0xa9, 0x6c, 0x56, 0xf4, 0xea, 0x65, 0x7a, 0xae, 0x08,
+  0xba, 0x78, 0x25, 0x2e, 0x1c, 0xa6, 0xb4, 0xc6, 0xe8, 0xdd, 0x74, 0x1f, 0x4b, 0xbd, 0x8b, 0x8a,
+  0x70, 0x3e, 0xb5, 0x66, 0x48, 0x03, 0xf6, 0x0e, 0x61, 0x35, 0x57, 0xb9, 0x86, 0xc1, 0x1d, 0x9e,
+  0xe1, 0xf8, 0x98, 0x11, 0x69, 0xd9, 0x8e, 0x94, 0x9b, 0x1e, 0x87, 0xe9, 0xce, 0x55, 0x28, 0xdf,
+  0x8c, 0xa1, 0x89, 0x0d, 0xbf, 0xe6, 0x42, 0x68, 0x41, 0x99, 0x2d, 0x0f, 0xb0, 0x54, 0xbb, 0x16 };
+
+#if (defined(CBC) && CBC == 1) || (defined(ECB) && ECB == 1)
+static const uint8_t rsbox[256] = {
+  0x52, 0x09, 0x6a, 0xd5, 0x30, 0x36, 0xa5, 0x38, 0xbf, 0x40, 0xa3, 0x9e, 0x81, 0xf3, 0xd7, 0xfb,
+  0x7c, 0xe3, 0x39, 0x82, 0x9b, 0x2f, 0xff, 0x87, 0x34, 0x8e, 0x43, 0x44, 0xc4, 0xde, 0xe9, 0xcb,
+  0x54, 0x7b, 0x94, 0x32, 0xa6, 0xc2, 0x23, 0x3d, 0xee, 0x4c, 0x95, 0x0b, 0x42, 0xfa, 0xc3, 0x4e,
+  0x08, 0x2e, 0xa1, 0x66, 0x28, 0xd9, 0x24, 0xb2, 0x76, 0x5b, 0xa2, 0x49, 0x6d, 0x8b, 0xd1, 0x25,
+  0x72, 0xf8, 0xf6, 0x64, 0x86, 0x68, 0x98, 0x16, 0xd4, 0xa4, 0x5c, 0xcc, 0x5d, 0x65, 0xb6, 0x92,
+  0x6c, 0x70, 0x48, 0x50, 0xfd, 0xed, 0xb9, 0xda, 0x5e, 0x15, 0x46, 0x57, 0xa7, 0x8d, 0x9d, 0x84,
+  0x90, 0xd8, 0xab, 0x00, 0x8c, 0xbc, 0xd3, 0x0a, 0xf7, 0xe4, 0x58, 0x05, 0xb8, 0xb3, 0x45, 0x06,
+  0xd0, 0x2c, 0x1e, 0x8f, 0xca, 0x3f, 0x0f, 0x02, 0xc1, 0xaf, 0xbd, 0x03, 0x01, 0x13, 0x8a, 0x6b,
+  0x3a, 0x91, 0x11, 0x41, 0x4f, 0x67, 0xdc, 0xea, 0x97, 0xf2, 0xcf, 0xce, 0xf0, 0xb4, 0xe6, 0x73,
+  0x96, 0xac, 0x74, 0x22, 0xe7, 0xad, 0x35, 0x85, 0xe2, 0xf9, 0x37, 0xe8, 0x1c, 0x75, 0xdf, 0x6e,
+  0x47, 0xf1, 0x1a, 0x71, 0x1d, 0x29, 0xc5, 0x89, 0x6f, 0xb7, 0x62, 0x0e, 0xaa, 0x18, 0xbe, 0x1b,
+  0xfc, 0x56, 0x3e, 0x4b, 0xc6, 0xd2, 0x79, 0x20, 0x9a, 0xdb, 0xc0, 0xfe, 0x78, 0xcd, 0x5a, 0xf4,
+  0x1f, 0xdd, 0xa8, 0x33, 0x88, 0x07, 0xc7, 0x31, 0xb1, 0x12, 0x10, 0x59, 0x27, 0x80, 0xec, 0x5f,
+  0x60, 0x51, 0x7f, 0xa9, 0x19, 0xb5, 0x4a, 0x0d, 0x2d, 0xe5, 0x7a, 0x9f, 0x93, 0xc9, 0x9c, 0xef,
+  0xa0, 0xe0, 0x3b, 0x4d, 0xae, 0x2a, 0xf5, 0xb0, 0xc8, 0xeb, 0xbb, 0x3c, 0x83, 0x53, 0x99, 0x61,
+  0x17, 0x2b, 0x04, 0x7e, 0xba, 0x77, 0xd6, 0x26, 0xe1, 0x69, 0x14, 0x63, 0x55, 0x21, 0x0c, 0x7d };
+#endif
+
+// The round constant word array, Rcon[i], contains the values given by 
+// x to the power (i-1) being powers of x (x is denoted as {02}) in the field GF(2^8)
+static const uint8_t Rcon[11] = {
+  0x8d, 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36 };
+
+/*
+ * Jordan Goulder points out in PR #12 (https://github.com/kokke/tiny-AES-C/pull/12),
+ * that you can remove most of the elements in the Rcon array, because they are unused.
+ *
+ * From Wikipedia's article on the Rijndael key schedule @ https://en.wikipedia.org/wiki/Rijndael_key_schedule#Rcon
+ * 
+ * "Only the first some of these constants are actually used – up to rcon[10] for AES-128 (as 11 round keys are needed), 
+ *  up to rcon[8] for AES-192, up to rcon[7] for AES-256. rcon[0] is not used in AES algorithm."
+ */
+
+
+/*****************************************************************************/
+/* Private functions:                                                        */
+/*****************************************************************************/
+/*
+static uint8_t getSBoxValue(uint8_t num)
+{
+  return sbox[num];
+}
+*/
+#define getSBoxValue(num) (sbox[(num)])
+
+// This function produces Nb(Nr+1) round keys. The round keys are used in each round to decrypt the states. 
+static void KeyExpansion(uint8_t* RoundKey, const uint8_t* Key)
+{
+  unsigned i, j, k;
+  uint8_t tempa[4]; // Used for the column/row operations
+  
+  // The first round key is the key itself.
+  for (i = 0; i < Nk; ++i)
+  {
+    RoundKey[(i * 4) + 0] = Key[(i * 4) + 0];
+    RoundKey[(i * 4) + 1] = Key[(i * 4) + 1];
+    RoundKey[(i * 4) + 2] = Key[(i * 4) + 2];
+    RoundKey[(i * 4) + 3] = Key[(i * 4) + 3];
+  }
+
+  // All other round keys are found from the previous round keys.
+  for (i = Nk; i < Nb * (Nr + 1); ++i)
+  {
+    {
+      k = (i - 1) * 4;
+      tempa[0]=RoundKey[k + 0];
+      tempa[1]=RoundKey[k + 1];
+      tempa[2]=RoundKey[k + 2];
+      tempa[3]=RoundKey[k + 3];
+
+    }
+
+    if (i % Nk == 0)
+    {
+      // This function shifts the 4 bytes in a word to the left once.
+      // [a0,a1,a2,a3] becomes [a1,a2,a3,a0]
+
+      // Function RotWord()
+      {
+        const uint8_t u8tmp = tempa[0];
+        tempa[0] = tempa[1];
+        tempa[1] = tempa[2];
+        tempa[2] = tempa[3];
+        tempa[3] = u8tmp;
+      }
+
+      // SubWord() is a function that takes a four-byte input word and 
+      // applies the S-box to each of the four bytes to produce an output word.
+
+      // Function Subword()
+      {
+        tempa[0] = getSBoxValue(tempa[0]);
+        tempa[1] = getSBoxValue(tempa[1]);
+        tempa[2] = getSBoxValue(tempa[2]);
+        tempa[3] = getSBoxValue(tempa[3]);
+      }
+
+      tempa[0] = tempa[0] ^ Rcon[i/Nk];
+    }
+#if defined(AES256) && (AES256 == 1)
+    if (i % Nk == 4)
+    {
+      // Function Subword()
+      {
+        tempa[0] = getSBoxValue(tempa[0]);
+        tempa[1] = getSBoxValue(tempa[1]);
+        tempa[2] = getSBoxValue(tempa[2]);
+        tempa[3] = getSBoxValue(tempa[3]);
+      }
+    }
+#endif
+    j = i * 4; k=(i - Nk) * 4;
+    RoundKey[j + 0] = RoundKey[k + 0] ^ tempa[0];
+    RoundKey[j + 1] = RoundKey[k + 1] ^ tempa[1];
+    RoundKey[j + 2] = RoundKey[k + 2] ^ tempa[2];
+    RoundKey[j + 3] = RoundKey[k + 3] ^ tempa[3];
+  }
+}
+
+void AES_init_ctx(struct AES_ctx* ctx, const uint8_t* key)
+{
+  KeyExpansion(ctx->RoundKey, key);
+}
+#if (defined(CBC) && (CBC == 1)) || (defined(CTR) && (CTR == 1))
+void AES_init_ctx_iv(struct AES_ctx* ctx, const uint8_t* key, const uint8_t* iv)
+{
+  KeyExpansion(ctx->RoundKey, key);
+  memcpy (ctx->Iv, iv, AES_BLOCKLEN);
+}
+void AES_ctx_set_iv(struct AES_ctx* ctx, const uint8_t* iv)
+{
+  memcpy (ctx->Iv, iv, AES_BLOCKLEN);
+}
+#endif
+
+// This function adds the round key to state.
+// The round key is added to the state by an XOR function.
+static void AddRoundKey(uint8_t round, state_t* state, const uint8_t* RoundKey)
+{
+  uint8_t i,j;
+  for (i = 0; i < 4; ++i)
+  {
+    for (j = 0; j < 4; ++j)
+    {
+      (*state)[i][j] ^= RoundKey[(round * Nb * 4) + (i * Nb) + j];
+    }
+  }
+}
+
+// The SubBytes Function Substitutes the values in the
+// state matrix with values in an S-box.
+static void SubBytes(state_t* state)
+{
+  uint8_t i, j;
+  for (i = 0; i < 4; ++i)
+  {
+    for (j = 0; j < 4; ++j)
+    {
+      (*state)[j][i] = getSBoxValue((*state)[j][i]);
+    }
+  }
+}
+
+// The ShiftRows() function shifts the rows in the state to the left.
+// Each row is shifted with different offset.
+// Offset = Row number. So the first row is not shifted.
+static void ShiftRows(state_t* state)
+{
+  uint8_t temp;
+
+  // Rotate first row 1 columns to left  
+  temp           = (*state)[0][1];
+  (*state)[0][1] = (*state)[1][1];
+  (*state)[1][1] = (*state)[2][1];
+  (*state)[2][1] = (*state)[3][1];
+  (*state)[3][1] = temp;
+
+  // Rotate second row 2 columns to left  
+  temp           = (*state)[0][2];
+  (*state)[0][2] = (*state)[2][2];
+  (*state)[2][2] = temp;
+
+  temp           = (*state)[1][2];
+  (*state)[1][2] = (*state)[3][2];
+  (*state)[3][2] = temp;
+
+  // Rotate third row 3 columns to left
+  temp           = (*state)[0][3];
+  (*state)[0][3] = (*state)[3][3];
+  (*state)[3][3] = (*state)[2][3];
+  (*state)[2][3] = (*state)[1][3];
+  (*state)[1][3] = temp;
+}
+
+static uint8_t xtime(uint8_t x)
+{
+  return ((x<<1) ^ (((x>>7) & 1) * 0x1b));
+}
+
+// MixColumns function mixes the columns of the state matrix
+static void MixColumns(state_t* state)
+{
+  uint8_t i;
+  uint8_t Tmp, Tm, t;
+  for (i = 0; i < 4; ++i)
+  {  
+    t   = (*state)[i][0];
+    Tmp = (*state)[i][0] ^ (*state)[i][1] ^ (*state)[i][2] ^ (*state)[i][3] ;
+    Tm  = (*state)[i][0] ^ (*state)[i][1] ; Tm = xtime(Tm);  (*state)[i][0] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][1] ^ (*state)[i][2] ; Tm = xtime(Tm);  (*state)[i][1] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][2] ^ (*state)[i][3] ; Tm = xtime(Tm);  (*state)[i][2] ^= Tm ^ Tmp ;
+    Tm  = (*state)[i][3] ^ t ;              Tm = xtime(Tm);  (*state)[i][3] ^= Tm ^ Tmp ;
+  }
+}
+
+// Multiply is used to multiply numbers in the field GF(2^8)
+// Note: The last call to xtime() is unneeded, but often ends up generating a smaller binary
+//       The compiler seems to be able to vectorize the operation better this way.
+//       See https://github.com/kokke/tiny-AES-c/pull/34
+#if MULTIPLY_AS_A_FUNCTION
+static uint8_t Multiply(uint8_t x, uint8_t y)
+{
+  return (((y & 1) * x) ^
+       ((y>>1 & 1) * xtime(x)) ^
+       ((y>>2 & 1) * xtime(xtime(x))) ^
+       ((y>>3 & 1) * xtime(xtime(xtime(x)))) ^
+       ((y>>4 & 1) * xtime(xtime(xtime(xtime(x)))))); /* this last call to xtime() can be omitted */
+  }
+#else
+#define Multiply(x, y)                                \
+      (  ((y & 1) * x) ^                              \
+      ((y>>1 & 1) * xtime(x)) ^                       \
+      ((y>>2 & 1) * xtime(xtime(x))) ^                \
+      ((y>>3 & 1) * xtime(xtime(xtime(x)))) ^         \
+      ((y>>4 & 1) * xtime(xtime(xtime(xtime(x))))))   \
+
+#endif
+
+#if (defined(CBC) && CBC == 1) || (defined(ECB) && ECB == 1)
+/*
+static uint8_t getSBoxInvert(uint8_t num)
+{
+  return rsbox[num];
+}
+*/
+#define getSBoxInvert(num) (rsbox[(num)])
+
+// MixColumns function mixes the columns of the state matrix.
+// The method used to multiply may be difficult to understand for the inexperienced.
+// Please use the references to gain more information.
+static void InvMixColumns(state_t* state)
+{
+  int i;
+  uint8_t a, b, c, d;
+  for (i = 0; i < 4; ++i)
+  { 
+    a = (*state)[i][0];
+    b = (*state)[i][1];
+    c = (*state)[i][2];
+    d = (*state)[i][3];
+
+    (*state)[i][0] = Multiply(a, 0x0e) ^ Multiply(b, 0x0b) ^ Multiply(c, 0x0d) ^ Multiply(d, 0x09);
+    (*state)[i][1] = Multiply(a, 0x09) ^ Multiply(b, 0x0e) ^ Multiply(c, 0x0b) ^ Multiply(d, 0x0d);
+    (*state)[i][2] = Multiply(a, 0x0d) ^ Multiply(b, 0x09) ^ Multiply(c, 0x0e) ^ Multiply(d, 0x0b);
+    (*state)[i][3] = Multiply(a, 0x0b) ^ Multiply(b, 0x0d) ^ Multiply(c, 0x09) ^ Multiply(d, 0x0e);
+  }
+}
+
+
+// The SubBytes Function Substitutes the values in the
+// state matrix with values in an S-box.
+static void InvSubBytes(state_t* state)
+{
+  uint8_t i, j;
+  for (i = 0; i < 4; ++i)
+  {
+    for (j = 0; j < 4; ++j)
+    {
+      (*state)[j][i] = getSBoxInvert((*state)[j][i]);
+    }
+  }
+}
+
+static void InvShiftRows(state_t* state)
+{
+  uint8_t temp;
+
+  // Rotate first row 1 columns to right  
+  temp = (*state)[3][1];
+  (*state)[3][1] = (*state)[2][1];
+  (*state)[2][1] = (*state)[1][1];
+  (*state)[1][1] = (*state)[0][1];
+  (*state)[0][1] = temp;
+
+  // Rotate second row 2 columns to right 
+  temp = (*state)[0][2];
+  (*state)[0][2] = (*state)[2][2];
+  (*state)[2][2] = temp;
+
+  temp = (*state)[1][2];
+  (*state)[1][2] = (*state)[3][2];
+  (*state)[3][2] = temp;
+
+  // Rotate third row 3 columns to right
+  temp = (*state)[0][3];
+  (*state)[0][3] = (*state)[1][3];
+  (*state)[1][3] = (*state)[2][3];
+  (*state)[2][3] = (*state)[3][3];
+  (*state)[3][3] = temp;
+}
+#endif // #if (defined(CBC) && CBC == 1) || (defined(ECB) && ECB == 1)
+
+// Cipher is the main function that encrypts the PlainText.
+static void Cipher(state_t* state, const uint8_t* RoundKey)
+{
+  uint8_t round = 0;
+
+  // Add the First round key to the state before starting the rounds.
+  AddRoundKey(0, state, RoundKey);
+
+  // There will be Nr rounds.
+  // The first Nr-1 rounds are identical.
+  // These Nr rounds are executed in the loop below.
+  // Last one without MixColumns()
+  for (round = 1; ; ++round)
+  {
+    SubBytes(state);
+    ShiftRows(state);
+    if (round == Nr) {
+      break;
+    }
+    MixColumns(state);
+    AddRoundKey(round, state, RoundKey);
+  }
+  // Add round key to last round
+  AddRoundKey(Nr, state, RoundKey);
+}
+
+#if (defined(CBC) && CBC == 1) || (defined(ECB) && ECB == 1)
+static void InvCipher(state_t* state, const uint8_t* RoundKey)
+{
+  uint8_t round = 0;
+
+  // Add the First round key to the state before starting the rounds.
+  AddRoundKey(Nr, state, RoundKey);
+
+  // There will be Nr rounds.
+  // The first Nr-1 rounds are identical.
+  // These Nr rounds are executed in the loop below.
+  // Last one without InvMixColumn()
+  for (round = (Nr - 1); ; --round)
+  {
+    InvShiftRows(state);
+    InvSubBytes(state);
+    AddRoundKey(round, state, RoundKey);
+    if (round == 0) {
+      break;
+    }
+    InvMixColumns(state);
+  }
+
+}
+#endif // #if (defined(CBC) && CBC == 1) || (defined(ECB) && ECB == 1)
+
+/*****************************************************************************/
+/* Public functions:                                                         */
+/*****************************************************************************/
+#if defined(ECB) && (ECB == 1)
+
+
+void AES_ECB_encrypt(const struct AES_ctx* ctx, uint8_t* buf)
+{
+  // The next function call encrypts the PlainText with the Key using AES algorithm.
+  Cipher((state_t*)buf, ctx->RoundKey);
+}
+
+void AES_ECB_decrypt(const struct AES_ctx* ctx, uint8_t* buf)
+{
+  // The next function call decrypts the PlainText with the Key using AES algorithm.
+  InvCipher((state_t*)buf, ctx->RoundKey);
+}
+
+
+#endif // #if defined(ECB) && (ECB == 1)
+
+
+
+
+
+#if defined(CBC) && (CBC == 1)
+
+
+static void XorWithIv(uint8_t* buf, const uint8_t* Iv)
+{
+  uint8_t i;
+  for (i = 0; i < AES_BLOCKLEN; ++i) // The block in AES is always 128bit no matter the key size
+  {
+    buf[i] ^= Iv[i];
+  }
+}
+
+void AES_CBC_encrypt_buffer(struct AES_ctx *ctx, uint8_t* buf, size_t length)
+{
+  size_t i;
+  uint8_t *Iv = ctx->Iv;
+  for (i = 0; i < length; i += AES_BLOCKLEN)
+  {
+    XorWithIv(buf, Iv);
+    Cipher((state_t*)buf, ctx->RoundKey);
+    Iv = buf;
+    buf += AES_BLOCKLEN;
+  }
+  /* store Iv in ctx for next call */
+  memcpy(ctx->Iv, Iv, AES_BLOCKLEN);
+}
+
+void AES_CBC_decrypt_buffer(struct AES_ctx* ctx, uint8_t* buf, size_t length)
+{
+  size_t i;
+  uint8_t storeNextIv[AES_BLOCKLEN];
+  for (i = 0; i < length; i += AES_BLOCKLEN)
+  {
+    memcpy(storeNextIv, buf, AES_BLOCKLEN);
+    InvCipher((state_t*)buf, ctx->RoundKey);
+    XorWithIv(buf, ctx->Iv);
+    memcpy(ctx->Iv, storeNextIv, AES_BLOCKLEN);
+    buf += AES_BLOCKLEN;
+  }
+
+}
+
+#endif // #if defined(CBC) && (CBC == 1)
+
+
+
+#if defined(CTR) && (CTR == 1)
+
+/* Symmetrical operation: same function for encrypting as for decrypting. Note any IV/nonce should never be reused with the same key */
+void AES_CTR_xcrypt_buffer(struct AES_ctx* ctx, uint8_t* buf, size_t length)
+{
+  uint8_t buffer[AES_BLOCKLEN];
+  
+  size_t i;
+  int bi;
+  for (i = 0, bi = AES_BLOCKLEN; i < length; ++i, ++bi)
+  {
+    if (bi == AES_BLOCKLEN) /* we need to regen xor compliment in buffer */
+    {
+      
+      memcpy(buffer, ctx->Iv, AES_BLOCKLEN);
+      Cipher((state_t*)buffer,ctx->RoundKey);
+
+      /* Increment Iv and handle overflow */
+      for (bi = (AES_BLOCKLEN - 1); bi >= 0; --bi)
+      {
+	/* inc will overflow */
+        if (ctx->Iv[bi] == 255)
+	{
+          ctx->Iv[bi] = 0;
+          continue;
+        } 
+        ctx->Iv[bi] += 1;
+        break;   
+      }
+      bi = 0;
+    }
+
+    buf[i] = (buf[i] ^ buffer[bi]);
+  }
+}
+
+#endif // #if defined(CTR) && (CTR == 1)
+

--- a/src/lorawan/lorawan.cpp
+++ b/src/lorawan/lorawan.cpp
@@ -2,31 +2,103 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <cstring>
+
+extern "C" {
+#include <lorawan/aes.h>
+}
 
 namespace lorawan {
 
 namespace {
-// Simple CRC32 implementation for MIC generation
-static uint32_t crc32(const uint8_t* data, size_t len) {
-    uint32_t crc = 0xFFFFFFFFu;
-    for (size_t i = 0; i < len; ++i) {
-        crc ^= data[i];
-        for (int j = 0; j < 8; ++j) {
-            if (crc & 1)
-                crc = (crc >> 1) ^ 0xEDB88320u;
-            else
-                crc >>= 1;
-        }
+
+static void left_shift_one(const uint8_t* in, uint8_t* out) {
+    uint8_t carry = 0;
+    for (int i = 15; i >= 0; --i) {
+        uint8_t b = in[i];
+        out[i] = static_cast<uint8_t>((b << 1) | carry);
+        carry = (b & 0x80) ? 1 : 0;
     }
-    return ~crc;
 }
+
+static void generate_subkeys(const AES_ctx* ctx, uint8_t* K1, uint8_t* K2) {
+    uint8_t L[16]{};
+    AES_ECB_encrypt(ctx, L);
+    left_shift_one(L, K1);
+    if (L[0] & 0x80) K1[15] ^= 0x87;
+    left_shift_one(K1, K2);
+    if (K1[0] & 0x80) K2[15] ^= 0x87;
+}
+
 } // namespace
 
-uint32_t compute_mic(const uint8_t* data, size_t len) {
-    return crc32(data, len);
+uint32_t compute_mic(const uint8_t nwk_skey[16],
+                     bool uplink,
+                     uint32_t devaddr,
+                     uint32_t fcnt,
+                     const uint8_t* data,
+                     size_t len) {
+    AES_ctx ctx;
+    AES_init_ctx(&ctx, nwk_skey);
+    uint8_t K1[16], K2[16];
+    generate_subkeys(&ctx, K1, K2);
+
+    uint8_t b0[16]{};
+    b0[0] = 0x49;
+    b0[5] = uplink ? 0 : 1;
+    b0[6] = static_cast<uint8_t>(devaddr & 0xFF);
+    b0[7] = static_cast<uint8_t>((devaddr >> 8) & 0xFF);
+    b0[8] = static_cast<uint8_t>((devaddr >> 16) & 0xFF);
+    b0[9] = static_cast<uint8_t>((devaddr >> 24) & 0xFF);
+    b0[10] = static_cast<uint8_t>(fcnt & 0xFF);
+    b0[11] = static_cast<uint8_t>((fcnt >> 8) & 0xFF);
+    b0[12] = static_cast<uint8_t>((fcnt >> 16) & 0xFF);
+    b0[13] = static_cast<uint8_t>((fcnt >> 24) & 0xFF);
+    b0[14] = static_cast<uint8_t>((len >> 8) & 0xFF);
+    b0[15] = static_cast<uint8_t>(len & 0xFF);
+
+    size_t total = len + 16;
+    size_t n = (total + 15) / 16;
+    bool flag = (total % 16) == 0;
+
+    uint8_t X[16]{};
+    uint8_t block[16];
+
+    // process all but last block
+    for (size_t i = 0; i < n - 1; ++i) {
+        for (int j = 0; j < 16; ++j) {
+            size_t pos = i * 16 + j;
+            uint8_t byte = pos < 16 ? b0[pos] : data[pos - 16];
+            block[j] = byte ^ X[j];
+        }
+        AES_ECB_encrypt(&ctx, block);
+        std::memcpy(X, block, 16);
+    }
+
+    // last block
+    size_t last_offset = (n - 1) * 16;
+    size_t bytes_in_last = total - last_offset;
+    uint8_t last[16]{};
+    for (size_t j = 0; j < bytes_in_last && j < 16; ++j) {
+        size_t pos = last_offset + j;
+        last[j] = pos < 16 ? b0[pos] : data[pos - 16];
+    }
+    if (flag) {
+        for (int j = 0; j < 16; ++j) last[j] ^= K1[j];
+    } else {
+        last[bytes_in_last] = 0x80;
+        for (int j = 0; j < 16; ++j) last[j] ^= K2[j];
+    }
+    for (int j = 0; j < 16; ++j) last[j] ^= X[j];
+    AES_ECB_encrypt(&ctx, last);
+    return static_cast<uint32_t>(last[0]) |
+           (static_cast<uint32_t>(last[1]) << 8) |
+           (static_cast<uint32_t>(last[2]) << 16) |
+           (static_cast<uint32_t>(last[3]) << 24);
 }
 
 ssize_t build_frame(lora_phy::lora_workspace* ws,
+                    const uint8_t nwk_skey[16],
                     const Frame& frame,
                     uint16_t* symbols,
                     size_t symbol_cap,
@@ -53,7 +125,9 @@ ssize_t build_frame(lora_phy::lora_workspace* ws,
     idx += frame.fhdr.fopts.size();
     std::copy(frame.payload.begin(), frame.payload.end(), tmp_bytes + idx);
     idx += frame.payload.size();
-    uint32_t mic = compute_mic(tmp_bytes, idx);
+    bool uplink = (static_cast<uint8_t>(frame.mhdr.mtype) & 1) == 0;
+    uint32_t mic = compute_mic(nwk_skey, uplink, frame.fhdr.devaddr,
+                               frame.fhdr.fcnt, tmp_bytes, idx);
     tmp_bytes[idx++] = static_cast<uint8_t>(mic & 0xFF);
     tmp_bytes[idx++] = static_cast<uint8_t>((mic >> 8) & 0xFF);
     tmp_bytes[idx++] = static_cast<uint8_t>((mic >> 16) & 0xFF);
@@ -62,6 +136,7 @@ ssize_t build_frame(lora_phy::lora_workspace* ws,
 }
 
 ssize_t parse_frame(lora_phy::lora_workspace* ws,
+                    const uint8_t nwk_skey[16],
                     const uint16_t* symbols,
                     size_t symbol_count,
                     Frame& out,
@@ -74,16 +149,21 @@ ssize_t parse_frame(lora_phy::lora_workspace* ws,
     if (produced < 0) return produced;
     if (static_cast<size_t>(produced) < 1 + 4 + 1 + 2 + 4) return -ERANGE;
     size_t len = static_cast<size_t>(produced);
+    uint8_t mhdr = tmp_bytes[0];
+    uint32_t devaddr = tmp_bytes[1] | (tmp_bytes[2] << 8) |
+                       (tmp_bytes[3] << 16) | (tmp_bytes[4] << 24);
+    uint16_t fcnt = tmp_bytes[6] | (tmp_bytes[7] << 8);
+    bool uplink = ((mhdr >> 5) & 1) == 0;
     uint32_t mic = tmp_bytes[len - 4] | (tmp_bytes[len - 3] << 8) |
                    (tmp_bytes[len - 2] << 16) | (tmp_bytes[len - 1] << 24);
-    uint32_t calc = compute_mic(tmp_bytes, len - 4);
+    uint32_t calc = compute_mic(nwk_skey, uplink, devaddr, fcnt,
+                                tmp_bytes, len - 4);
     if (mic != calc) return -EINVAL;
     size_t idx = 0;
-    uint8_t mhdr = tmp_bytes[idx++];
     out.mhdr.mtype = static_cast<MType>(mhdr >> 5);
     out.mhdr.major = mhdr & 0x3;
-    out.fhdr.devaddr = tmp_bytes[idx] | (tmp_bytes[idx + 1] << 8) |
-                       (tmp_bytes[idx + 2] << 16) | (tmp_bytes[idx + 3] << 24);
+    idx = 1;
+    out.fhdr.devaddr = devaddr;
     idx += 4;
     out.fhdr.fctrl = tmp_bytes[idx++];
     unsigned fopts_len = out.fhdr.fctrl & 0x0F;

--- a/tests/lorawan_mic_test.cpp
+++ b/tests/lorawan_mic_test.cpp
@@ -1,0 +1,16 @@
+#include <lorawan/lorawan.hpp>
+#include <algorithm>
+#include <cstdint>
+#include <iostream>
+
+int lorawan_mic_test_main() {
+    uint8_t nwk_skey[16];
+    std::fill(std::begin(nwk_skey), std::end(nwk_skey), 2);
+    uint8_t msg[] = {0x40,0x04,0x03,0x02,0x01,0x80,0x01,0x00,0x01,0xA6,0x94,0x64,0x26,0x15};
+    uint32_t mic = lorawan::compute_mic(nwk_skey, true, 0x01020304, 1, msg, sizeof(msg));
+    if (mic != 0x82B5C3D6u) {
+        std::cerr << "mic mismatch\n";
+        return 1;
+    }
+    return 0;
+}

--- a/tests/test_main.cpp
+++ b/tests/test_main.cpp
@@ -11,6 +11,7 @@ int sync_word_test_main();
 int error_code_test_main();
 int odd_symbol_count_test_main();
 int scratch_buffer_error_test_main();
+int lorawan_mic_test_main();
 
 int main() {
     int result = 0;
@@ -25,6 +26,7 @@ int main() {
     result |= error_code_test_main();
     result |= odd_symbol_count_test_main();
     result |= scratch_buffer_error_test_main();
+    result |= lorawan_mic_test_main();
     if (result != 0) {
         std::printf("Some tests failed\n");
     }


### PR DESCRIPTION
## Summary
- replace CRC32 MIC with AES-128 CMAC per LoRaWAN spec
- document MIC API changes and new network key parameters
- add LoRaWAN MIC test vector and lightweight AES implementation

## Testing
- `cmake -S . -B build`
- `cmake --build build`
- `cd build && ctest` *(fails: profile vector mismatches and heap corruption)*

------
https://chatgpt.com/codex/tasks/task_e_68c0346a56148329b9b82c441eaa7e94