### PR TITLE
Copy test data to build directory for tests

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,18 @@ if(BUILD_TESTS)
     file(GLOB TEST_SOURCES CONFIGURE_DEPENDS tests/*.cpp)
     list(REMOVE_ITEM TEST_SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_main.cpp)
 
+    # Copy test data files so the tests can be executed from the build
+    # directory without relying on the source tree layout.  The tests load
+    # profiles.yaml and various golden vectors using paths relative to the
+    # current working directory (e.g. "tests/profiles.yaml").  When running
+    # lora_phy_tests directly from the build directory these files would not
+    # be found.  Replicate the expected directory structure in the binary tree
+    # to make the resources available.
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/tests/profiles.yaml
+         DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/tests)
+    file(COPY ${CMAKE_CURRENT_SOURCE_DIR}/vectors
+         DESTINATION ${CMAKE_CURRENT_BINARY_DIR})
+
     add_executable(lora_phy_tests tests/test_main.cpp ${TEST_SOURCES} src/lorawan/lorawan.cpp src/lorawan/aes.c)
     target_link_libraries(lora_phy_tests PRIVATE lora_phy)
 


### PR DESCRIPTION
## Summary
- Copy `tests/profiles.yaml` and `vectors` into the build tree so `lora_phy_tests` can run from the build directory

## Testing
- `cmake ..`
- `make -j$(nproc)`
- `./lora_phy_tests` *(fails: Mismatch in profile sf7_bw125_cr45)*

------
https://chatgpt.com/codex/tasks/task_e_68c045b91dd0832987c1a1d25a534df1